### PR TITLE
feature: add reserved keywords support, refactor tests

### DIFF
--- a/lex/main.py
+++ b/lex/main.py
@@ -1,6 +1,22 @@
 import ply.lex as lex
 
-tokens = (
+reserved = {
+    'if' : 'IF',
+    'else' : 'ELSE',
+    'while' : 'WHILE',
+    'for' : 'FOR',
+    'void': 'VOID',
+    'char': 'CHAR',
+    'int': 'INT',
+    'float': 'FLOAT',
+    'break': 'BREAK',
+    'return': 'RETURN',
+    'assert': 'ASSERT',
+    'print': 'PRINT',
+    'read': 'READ'
+}
+
+tokens = [
     'CCOMMENT',
     'UCCCOMMENT',
     'ID',
@@ -15,7 +31,7 @@ tokens = (
     'INT_CONST',
     'FLOAT_CONST',
     'STRING_CONST',
-)
+] + list(reserved.values())
 
 t_EQUALS = r'\='
 t_PLUS = r'\+'
@@ -38,6 +54,7 @@ def t_UCCOMMENT(t):
 
 def t_ID(t):
     r'[a-zA-Z_][a-zA-Z_0-9]*'
+    t.type = reserved.get(t.value,'ID')    # Check for reserved words
     return t
 
 

--- a/tests/lex_data.py
+++ b/tests/lex_data.py
@@ -1,8 +1,14 @@
-lex_test = '''
+lex_identifier_test = '''
 _int = 333
 float1 = 444.4
 string = "Hello World\n"
 // test inline comment
 /* test block comment */
 /* "This is a string inside a block comment" */
+'''
+
+lex_reserved_test = '''
+if void else char for break
+while float assert int
+print read return
 '''

--- a/tests/test_lex_identifiers.py
+++ b/tests/test_lex_identifiers.py
@@ -1,21 +1,3 @@
-from tests.data import lex_test
-
-
-def test_lexer(lex):
-    """
-    Integration test for the lexer
-    :return:
-    """
-    lex.input(lex_test)
-
-    while True:
-        tok = lex.token()
-        if not tok:
-            break  # No more input
-        print(tok)
-    pass
-
-
 def test_ccomment(lex):
     lex.input('/* test block comment */')
 
@@ -33,15 +15,18 @@ def test_ucomment(lex):
 def test_id(lex):
     lex.input('_int')
     tok = lex.token()
-    assert str(tok) == "LexToken(ID,'_int',8,0)"
+    assert tok.type == 'ID'
+    assert tok.value == '_int'
 
     lex.input('_float1')
     tok = lex.token()
-    assert str(tok) == "LexToken(ID,'_float1',8,0)"
+    assert tok.type == 'ID'
+    assert tok.value == '_float1'
 
     lex.input('string')
     tok = lex.token()
-    assert str(tok) == "LexToken(ID,'string',8,0)"
+    assert tok.type == 'ID'
+    assert tok.value == 'string'
 
 
 def test_newline(lex):
@@ -53,20 +38,25 @@ def test_newline(lex):
 def test_int_const(lex):
     lex.input('3412')
     tok = lex.token()
-    assert str(tok) == 'LexToken(INT_CONST,3412,9,0)'
+    assert tok.type == 'INT_CONST'
+    assert tok.value == 3412
 
 
 def test_float_const(lex):
     lex.input('222.4')
     tok = lex.token()
-    assert str(tok) == 'LexToken(FLOAT_CONST,222.4,9,0)'
+    assert tok.type == 'FLOAT_CONST'
+    assert tok.value == 222.4
+
     lex.input('.4')
     tok = lex.token()
-    assert str(tok) == 'LexToken(FLOAT_CONST,0.4,9,0)'
+    assert tok.type == 'FLOAT_CONST'
+    assert tok.value == 0.4
 
 
 def test_string_const(lex):
     lex.input('"Hello World"')
     tok = lex.token()
-    assert str(tok) == 'LexToken(STRING_CONST,\'"Hello World"\',9,0)'
+    assert tok.type == 'STRING_CONST'
+    assert tok.value == '"Hello World"'
 

--- a/tests/test_lex_integration.py
+++ b/tests/test_lex_integration.py
@@ -1,0 +1,70 @@
+lex_identifier_test = '''
+_int = 333
+float1 = 444.4
+string = "Hello World\n"
+// test inline comment
+/* test block comment */
+/* "This is a string inside a block comment" */
+'''
+
+lex_reserved_test = '''
+if void else char for break
+while float assert int
+print read return
+'''
+
+lex_test_all = '''
+// test inline comment
+if void else char for break
+
+/* test block comment */
+/* "This is a string inside a block comment" */
+_int = 333
+float1 = 444.4
+string = "Hello World\n"
+
+while float assert int
+print read return
+'''
+
+def test_lex_identifiers(lex):
+    """
+    Integration test for the lex, tests identifiers
+    :return:
+    """
+    lex.input(lex_identifier_test)
+
+    while True:
+        tok = lex.token()
+        if not tok:
+            break  # No more input
+        print(tok)
+    pass
+
+def test_lex_reserved(lex):
+    """
+    Integration test for the lex, tests reserved keywords
+    :return:
+    """
+    lex.input(lex_reserved_test)
+
+    while True:
+        tok = lex.token()
+        if not tok:
+            break  # No more input
+        print(tok)
+    pass
+
+def test_lex_all(lex):
+    """
+    Integration test for the lexer, test all possible cases
+    :return:
+    """
+    lex.input(lex_test_all)
+
+    while True:
+        tok = lex.token()
+        if not tok:
+            break  # No more input
+        print(tok)
+    pass

--- a/tests/test_lex_reserved.py
+++ b/tests/test_lex_reserved.py
@@ -1,0 +1,4 @@
+def test_if(lex):
+    lex.input('if')
+    tok = lex.token()
+    assert str(tok.type) == 'IF'


### PR DESCRIPTION
If applied this PR will add reserved keywords support and will include tests for it while also refactoring some of the tests files.

There are some things that I don't like that I couldn't fix in relation to the tests:
  * I want a directory just for lex and a file/dir with the data for the integration tests, but I wasn't able to get the imports right
  * Integration tests arent testing anything as of right now (everything passes), we need some stricter assertions.

closes: #3 